### PR TITLE
Switch base url from app.close.io to api.close.com

### DIFF
--- a/lib/ex_closeio/base.ex
+++ b/lib/ex_closeio/base.ex
@@ -2,7 +2,7 @@ defmodule ExCloseio.Base do
   @moduledoc """
   Provides general request making and handling functionality (for internal use).
   """
-  @base_url "https://app.close.io/api/v1"
+  @base_url "https://api.close.com/api/v1"
   @headers  [{"User-Agent", "ExCloseio"}, {"Content-Type", "application/json"}]
 
   @doc """


### PR DESCRIPTION
Hey @taylorbrooks --

This one is the same as the other ones I've sent over recently to change the base url of the repo to the new `api.close.com` :) 